### PR TITLE
fix changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
-	"changelog": ["@svitejs/changesets-changelog-github-compact", {"repo": "feltjs/gro"}],
+	"changelog": "@changesets/cli/changelog",
 	"commit": false,
 	"fixed": [],
 	"linked": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "@feltjs/eslint-config": "^0.3.0",
         "@sveltejs/adapter-static": "^2.0.2",
         "@sveltejs/kit": "^1.22.3",
-        "@svitejs/changesets-changelog-github-compact": "^1.1.0",
         "@types/estree": "^1.0.1",
         "@types/fs-extra": "^11.0.1",
         "@types/node": "^20.3.2",
@@ -80,16 +79,6 @@
         "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@changesets/get-github-info": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.5.2.tgz",
-      "integrity": "sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==",
-      "dev": true,
-      "dependencies": {
-        "dataloader": "^1.4.0",
-        "node-fetch": "^2.5.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -767,19 +756,6 @@
         "vite": "^4.0.0"
       }
     },
-    "node_modules/@svitejs/changesets-changelog-github-compact": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@svitejs/changesets-changelog-github-compact/-/changesets-changelog-github-compact-1.1.0.tgz",
-      "integrity": "sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==",
-      "dev": true,
-      "dependencies": {
-        "@changesets/get-github-info": "^0.5.2",
-        "dotenv": "^16.0.3"
-      },
-      "engines": {
-        "node": "^14.13.1 || ^16.0.0 || >=18"
-      }
-    },
     "node_modules/@types/cookie": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
@@ -1361,12 +1337,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/dataloader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
-      "dev": true
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1453,18 +1423,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2374,26 +2332,6 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3225,12 +3163,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "node_modules/tslib": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
@@ -3408,22 +3340,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@feltjs/eslint-config": "^0.3.0",
     "@sveltejs/adapter-static": "^2.0.2",
     "@sveltejs/kit": "^1.22.3",
-    "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "@types/estree": "^1.0.1",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^20.3.2",

--- a/src/docs/publish.md
+++ b/src/docs/publish.md
@@ -44,19 +44,6 @@ If your package is public, configure the `access` property:
 + "access": "public",
 ```
 
-Optionally install a custom changelog generator like
-[`@svitejs/changesets-changelog-github-compact`](https://github.com/svitejs/changesets-changelog-github-compact):
-
-```bash
-npm i -D @svitejs/changesets-changelog-github-compact
-```
-
-```diff
-# .changeset/config.json
-- "changelog": "@changesets/cli/changelog",
-+ "changelog": ["@svitejs/changesets-changelog-github-compact", {"repo": "org/repo"}],
-```
-
 To [add](https://github.com/changesets/changesets/blob/main/packages/cli/README.md#add) a changeset:
 
 ```bash


### PR DESCRIPTION
`@svitejs/changesets-changelog-github-compact` has an unexpected dependency on GitHub access tokens, so this reverts to the default.

I'll look at `@changesets/changelog-git` as a potential replacement once it's working, or maybe make a custom one.