### PR TITLE
rename VocabSchema to JsonSchema

### DIFF
--- a/.changeset/shy-peas-invent.md
+++ b/.changeset/shy-peas-invent.md
@@ -1,0 +1,5 @@
+---
+'@feltjs/gro': minor
+---
+
+rename VocabSchema to JsonSchema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 ## 0.77.0
 
-- **break**: move `toVocabSchema` to `$lib/schemaHelpers.ts` and export all of `$lib/schema.ts`
+- **break**: move `toJsonSchema` to `$lib/schemaHelpers.ts` and export all of `$lib/schema.ts`
   ([commit](https://github.com/feltjs/gro/commit/21a107633f950ffb540b180b57fc3227146993c5))
 
 ## 0.76.1
@@ -68,7 +68,7 @@
 
 ## 0.76.0
 
-- **break**: change `toVocabSchema` to not suffix with `.json`, and add the `bundleSchemas` helper
+- **break**: change `toJsonSchema` to not suffix with `.json`, and add the `bundleSchemas` helper
   ([#372](https://github.com/feltjs/gro/pull/372))
 
 ## 0.75.5
@@ -79,7 +79,7 @@
 
 ## 0.75.4
 
-- export `VocabSchema` type from root
+- export `JsonSchema` type from root
   ([commit](https://github.com/feltjs/gro/commit/8b3956994060165cccf7c0d6b692ea8e89b7e63a))
 
 ## 0.75.3

--- a/src/docs/gen.md
+++ b/src/docs/gen.md
@@ -111,7 +111,7 @@ to automatically generate TypeScript types using
 Given `src/something.schema.ts`:
 
 ```ts
-export const SomeObjectSchema: VocabSchema = {
+export const SomeObjectSchema: JsonSchema = {
 	$id: '/schemas/SomeObject',
 	type: 'object',
 	properties: {
@@ -152,7 +152,7 @@ Some details:
 - `.schema.` modules may export any number of schemas:
   all top-level exports with the JSONSchema
   [`$id`](https://json-schema.org/draft/2020-12/json-schema-core.html#anchor) property
-  are considered to be vocab schemas by `isVocabSchema` (this detection may need tweaking)
+  are considered to be vocab schemas by `isJsonSchema` (this detection may need tweaking)
 - vocab schemas suffixed with `Schema` will output types without the suffix,
   as a convenience to avoid name collisions
   (note that your declared `$id` should omit the suffix)

--- a/src/gen/fixtures/someTestObject.schema.ts
+++ b/src/gen/fixtures/someTestObject.schema.ts
@@ -1,6 +1,6 @@
-import type {VocabSchema} from '../../utils/schema.js';
+import type {JsonSchema} from '../../utils/schema.js';
 
-export const SomeTestObjectSchema: VocabSchema = {
+export const SomeTestObjectSchema: JsonSchema = {
 	$id: '/schemas/SomeTestObject',
 	type: 'object',
 	properties: {
@@ -35,7 +35,7 @@ export const SomeTestObjectSchema: VocabSchema = {
 	additionalProperties: false,
 };
 
-export const SomeTestPrimitiveSchema: VocabSchema = {
+export const SomeTestPrimitiveSchema: JsonSchema = {
 	$id: '/schemas/SomeTestPrimitive',
 	type: 'number',
 };

--- a/src/gen/genSchemas.ts
+++ b/src/gen/genSchemas.ts
@@ -13,7 +13,7 @@ import {
 } from './genModule.js';
 import {renderTsHeaderAndFooter} from './helpers/ts.js';
 import {normalizeTypeImports} from './helpers/typeImports.js';
-import {inferSchemaTypes, isVocabSchema, type VocabSchema} from '../utils/schema.js';
+import {inferSchemaTypes, isJsonSchema, type JsonSchema} from '../utils/schema.js';
 
 export const genSchemas = async (
 	mod: SchemaGenModule,
@@ -72,8 +72,8 @@ const runSchemaGen = async (
 	return {imports, types};
 };
 
-export const toSchemasFromModules = (genModules: GenModuleMeta[]): VocabSchema[] => {
-	const schemas: VocabSchema[] = [];
+export const toSchemasFromModules = (genModules: GenModuleMeta[]): JsonSchema[] => {
+	const schemas: JsonSchema[] = [];
 	for (const genModule of genModules) {
 		if (genModule.type !== 'schema') continue;
 		for (const schemaInfo of toSchemaInfoFromModule(genModule.mod)) {
@@ -85,11 +85,11 @@ export const toSchemasFromModules = (genModules: GenModuleMeta[]): VocabSchema[]
 
 const toSchemaInfoFromModule = (
 	mod: SchemaGenModule,
-): Array<{identifier: string; schema: VocabSchema}> => {
-	const schemaInfo: Array<{identifier: string; schema: VocabSchema}> = [];
+): Array<{identifier: string; schema: JsonSchema}> => {
+	const schemaInfo: Array<{identifier: string; schema: JsonSchema}> = [];
 	for (const identifier in mod) {
 		const value = mod[identifier];
-		if (isVocabSchema(value)) schemaInfo.push({identifier, schema: value});
+		if (isJsonSchema(value)) schemaInfo.push({identifier, schema: value});
 	}
 	return schemaInfo;
 };

--- a/src/gen/runGen.ts
+++ b/src/gen/runGen.ts
@@ -23,7 +23,7 @@ import {
 import type {Filesystem} from '../fs/filesystem.js';
 import {printPath, sourceIdToBasePath} from '../paths.js';
 import {genSchemas, toSchemasFromModules} from './genSchemas.js';
-import {toVocabSchemaResolver} from '../utils/schema.js';
+import {toJsonSchemaResolver} from '../utils/schema.js';
 
 export const GEN_NO_PROD_MESSAGE = 'gen runs only during development';
 
@@ -120,7 +120,7 @@ const toGenSchemasOptions = (
 		$refOptions: {
 			resolve: {
 				http: false, // disable web resolution
-				vocab: toVocabSchemaResolver(schemas),
+				vocab: toJsonSchemaResolver(schemas),
 			},
 		},
 	};

--- a/src/task/logTask.ts
+++ b/src/task/logTask.ts
@@ -6,7 +6,7 @@ import {printValue} from '@feltjs/util/print.js';
 import type {ArgSchema, ArgsSchema} from '../utils/args.js';
 import {loadModules} from '../fs/modules.js';
 import {loadTaskModule, type TaskModuleMeta} from './taskModule.js';
-import {toVocabSchema} from '../utils/schemaHelpers.js';
+import {toJsonSchema} from '../utils/schemaHelpers.js';
 
 export const logAvailableTasks = async (
 	log: Logger,
@@ -60,8 +60,8 @@ export const logTaskHelp = (log: Logger, meta: TaskModuleMeta): void => {
 	const printed: string[] = [];
 	printed.push(cyan(name), 'help', '\n' + task.summary || '(no summary available)');
 	if (task.Args) {
-		// TODO refactor to avoid using `toVocabSchema`, and then remove the `zodToJsonSchema` dep
-		const args = toVocabSchema(task.Args, 'Args') as ArgsSchema;
+		// TODO refactor to avoid using `toJsonSchema`, and then remove the `zodToJsonSchema` dep
+		const args = toJsonSchema(task.Args, 'Args') as ArgsSchema;
 		const properties = toArgProperties(args);
 		const longestTaskName = Math.max(
 			ARGS_PROPERTY_NAME.length,

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -3,12 +3,12 @@ import type {JSONSchema} from '@ryanatkn/json-schema-to-typescript';
 import type {ResolverOptions} from 'json-schema-ref-parser';
 import type {GenContext} from '../gen/gen';
 
-export interface VocabSchema extends JSONSchema {
+export interface JsonSchema extends JSONSchema {
 	$id: string;
 }
 
 /**
- * Bundles an array of `VocabSchema`s into a single spec-compliant `JSONSchema`
+ * Bundles an array of `JsonSchema`s into a single spec-compliant `JSONSchema`
  * with the given `$id` and `title`.
  * @see https://json-schema.org/draft/2020-12/json-schema-core.html#name-bundling
  * @see https://json-schema.org/understanding-json-schema/structuring.html#bundling
@@ -19,7 +19,7 @@ export interface VocabSchema extends JSONSchema {
  * @returns
  */
 export const bundleSchemas = (
-	schemas: VocabSchema[],
+	schemas: JsonSchema[],
 	$id: string,
 	title: string | undefined = undefined,
 	$schema = 'https://json-schema.org/draft/2020-12/schema',
@@ -33,19 +33,19 @@ export const bundleSchemas = (
 			if (!name) throw Error(`Unable to parse schema name: "${schema.$id}"`);
 			$defs[name] = schema;
 			return $defs;
-		}, {} as Record<string, VocabSchema>);
+		}, {} as Record<string, JsonSchema>);
 	return schema;
 };
 
-export const isVocabSchema = (value: unknown): value is VocabSchema =>
+export const isJsonSchema = (value: unknown): value is JsonSchema =>
 	!!value && typeof value === 'object' && '$id' in value;
 
 /**
- * Creates a custom resolver for `VocabSchema`s supporting refs like `/schemas/Something`.
+ * Creates a custom resolver for `JsonSchema`s supporting refs like `/schemas/Something`.
  * @param schemas
  * @returns
  */
-export const toVocabSchemaResolver = (schemas: VocabSchema[]): ResolverOptions => ({
+export const toJsonSchemaResolver = (schemas: JsonSchema[]): ResolverOptions => ({
 	order: 1,
 	canRead: true,
 	read: (file) => {
@@ -59,7 +59,7 @@ export const toVocabSchemaResolver = (schemas: VocabSchema[]): ResolverOptions =
  * Mutates `schema` with `tsType` and `tsImport`, if appropriate.
  * @param schema
  */
-export const inferSchemaTypes = (schema: VocabSchema, ctx: GenContext): void => {
+export const inferSchemaTypes = (schema: JsonSchema, ctx: GenContext): void => {
 	traverse(schema, (key, value, obj) => {
 		if (key === '$ref') {
 			if (!('tsType' in obj)) {

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -3,9 +3,13 @@ import {zodToJsonSchema} from 'zod-to-json-schema';
 
 import type {JsonSchema} from './schema.js';
 
-export const toJsonSchema = (t: z.ZodType<any, z.ZodTypeDef, any>, name: string): JsonSchema => {
+export const toJsonSchema = (
+	t: z.ZodType<any, z.ZodTypeDef, any>,
+	name: string,
+	prefix = '/schemas/',
+): JsonSchema => {
 	const schema = zodToJsonSchema(t, name);
 	const args = (schema.definitions ? schema.definitions[name] : {}) as JsonSchema;
-	args.$id = `/schemas/${name}`;
+	args.$id = prefix + name;
 	return args;
 };

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -1,11 +1,11 @@
 import type z from 'zod';
 import {zodToJsonSchema} from 'zod-to-json-schema';
 
-import type {VocabSchema} from './schema.js';
+import type {JsonSchema} from './schema.js';
 
-export const toVocabSchema = (t: z.ZodType<any, z.ZodTypeDef, any>, name: string): VocabSchema => {
+export const toJsonSchema = (t: z.ZodType<any, z.ZodTypeDef, any>, name: string): JsonSchema => {
 	const schema = zodToJsonSchema(t, name);
-	const args = (schema.definitions ? schema.definitions[name] : {}) as VocabSchema;
+	const args = (schema.definitions ? schema.definitions[name] : {}) as JsonSchema;
 	args.$id = `/schemas/${name}`;
 	return args;
 };


### PR DESCRIPTION
"vocab" is something that's app-specific, and Gro's schemas are any JSONSchema, so this corrects a misnomer.