### PR TITLE
use `--import` instead of `--loader`

### DIFF
--- a/.changeset/little-frogs-reflect.md
+++ b/.changeset/little-frogs-reflect.md
@@ -1,0 +1,5 @@
+---
+"@grogarden/gro": minor
+---
+
+upgrade node@20.10

--- a/.changeset/mighty-countries-shout.md
+++ b/.changeset/mighty-countries-shout.md
@@ -1,0 +1,5 @@
+---
+"@grogarden/gro": patch
+---
+
+use `--import` instead of `--loader`

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.7]
+        node-version: [20.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.10]
+        node-version: ['20.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ It includes:
 
 ## install
 
-> depends on node >=20.7
+> depends on node >=20.10
 
 Typical usage installs [@grogarden/gro](https://www.npmjs.com/package/@grogarden/gro)
 as a dev dependency:

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "uvu": "^0.5.6"
       },
       "engines": {
-        "node": ">=20.7"
+        "node": ">=20.10"
       },
       "peerDependencies": {
         "esbuild": "^0.18.20",
@@ -542,7 +542,7 @@
       "integrity": "sha512-LLSV8JlYwB+aO89wRdguSczI8lI1iU+dEnvZrMW8INKkGlRr1SPmTzPM9KjEe8gz7cxxfmpPiEtOniAUgalCFw==",
       "dev": true,
       "engines": {
-        "node": ">=20.7"
+        "node": ">=20.10"
       },
       "peerDependencies": {
         "svelte": "*"
@@ -554,7 +554,7 @@
       "integrity": "sha512-3c4GOZiHX5lkDhdWLrqoUjpZVgU9tbShKa801jj9gmqVMPgJqTMhi25orHQoY0LBe2VPToPYqc27/4A8LAUqdg==",
       "dev": true,
       "engines": {
-        "node": ">=20.7"
+        "node": ">=20.10"
       },
       "peerDependencies": {
         "@grogarden/util": "*",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20.7"
+    "node": ">=20.10"
   },
   "scripts": {
     "build": "rm -rf .gro dist && svelte-package && chmod +x ./dist/gro.js && npm link -f",

--- a/src/lib/gro.ts
+++ b/src/lib/gro.ts
@@ -63,7 +63,10 @@ if (await exists(gro_bin_path)) {
 	}
 }
 
+
 const result = await spawn('node', [
+	// '--import',
+	// 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("/home/lap/dev/gro/dist/loader.js", pathToFileURL("./"));',
 	'--loader',
 	join(path, '../loader.js'),
 	path,

--- a/src/lib/gro.ts
+++ b/src/lib/gro.ts
@@ -67,9 +67,10 @@ const loader_path = join(path, '../loader.js');
 
 const result = await spawn('node', [
 	'--import',
-	`data:text/javascript,import {register} from "node:module"; import {pathToFileURL} from "node:url"; register("${loader_path}", pathToFileURL("./"));`,
-	// '--loader',
-	// loader_path,
+	`data:text/javascript,
+		import {register} from "node:module";
+		import {pathToFileURL} from "node:url";
+		register("${loader_path}", pathToFileURL("./"));`,
 	path,
 	...process.argv.slice(2),
 ]);

--- a/src/lib/gro.ts
+++ b/src/lib/gro.ts
@@ -63,12 +63,13 @@ if (await exists(gro_bin_path)) {
 	}
 }
 
+const loader_path = join(path, '../loader.js');
 
 const result = await spawn('node', [
-	// '--import',
-	// 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("/home/lap/dev/gro/dist/loader.js", pathToFileURL("./"));',
-	'--loader',
-	join(path, '../loader.js'),
+	'--import',
+	`data:text/javascript,import {register} from "node:module"; import {pathToFileURL} from "node:url"; register("${loader_path}", pathToFileURL("./"));`,
+	// '--loader',
+	// loader_path,
 	path,
 	...process.argv.slice(2),
 ]);

--- a/src/lib/package.ts
+++ b/src/lib/package.ts
@@ -16,7 +16,7 @@ export const package_json = {
 	repository: {type: 'git', url: 'git+https://github.com/grogarden/gro.git'},
 	bugs: {url: 'https://github.com/grogarden/gro/issues', email: 'mail@ryanatkn.com'},
 	type: 'module',
-	engines: {node: '>=20.7'},
+	engines: {node: '>=20.10'},
 	scripts: {
 		build: 'rm -rf .gro dist && svelte-package && chmod +x ./dist/gro.js && npm link -f',
 		start: 'gro dev',


### PR DESCRIPTION
Node's helpfully giving the migration as a runtime warning, `--loader` is no longer the way to load the loader, `--import` with `register` is. (maybe loader isn't the right word any more?)